### PR TITLE
feat: v2 - signed stewardship attestation schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,33 @@
 # Sporechain
 
-Sporechain defines a minimal, shared record type for biodiversity data on [AT Protocol](https://atproto.com/). The protocol layer is deliberately small — a single entry type with five fields — leaving categorization, curation, and content infrastructure to the federation layer above.
+Sporechain defines a signed stewardship attestation record for biodiversity data on [AT Protocol](https://atproto.com/). The protocol layer is deliberately small — a single entry type — leaving categorization, curation, and content infrastructure to the federation layer above.
 
 ## The entry
 
 ```
 network.sporechain.entry
-├── subject    (string, required) — Scientific name. The taxonomic anchor.
-├── tags       (string[], max 8) — Classification tags.
-├── cid        (string) — IPFS CID pointing to content payload.
-├── parents    (at-uri[], max 3) — DAG linkage to parent entries.
-└── createdAt  (datetime, required)
+├── subject          (string, required)   — Scientific name. The taxonomic anchor.
+├── kind             (string, required)   — What this entry does (see below).
+├── cid              (string)             — IPFS CID pointing to content payload.
+├── sourceUri        (string)             — Original locator (https://, at://, doi:).
+├── sourceCollection (string)             — Semantic source label (e.g. gbif:occurrence:1234).
+├── mirroredAt       (datetime)           — When content was pinned/snapshotted.
+├── tags             (string[])           — Classification: record type, kingdom, provenance, custom.
+├── parents          (at-uri[])           — DAG linkage for lineage, provenance, context.
+└── createdAt        (datetime, required)
 ```
 
-The entry is the link, not the content. Content lives on IPFS. Entries are lightweight, signed, and portable.
+The entry is a signed pointer, not a container. Content lives on IPFS. Identity lives on AT Protocol. The entry sits between them as a thin index: "this identity attests to this content at this time."
 
+## Entry kinds
+
+The `kind` field uses `knownValues` — these five are documented conventions, but the field accepts any string for future extensibility.
+
+- **mirroredRecord** — Off-protocol structured data (DwC-A row, GBIF snapshot) pinned to IPFS.
+- **mirroredDocument** — Off-protocol unstructured content (NEPA PDF, field guide scan) pinned to IPFS.
+- **archivedAtprotoRecord** — On-protocol record snapshotted because the source is unreliable or at risk.
+- **pinningAttestation** — Live AT Protocol record the federation has formally committed to stewarding.
+- **witness** — Timestamp-only attestation. No new pin, just a signed statement that something existed.
 
 ## Lexicon
 

--- a/lexicons/network/sporechain/entry.json
+++ b/lexicons/network/sporechain/entry.json
@@ -31,7 +31,6 @@
             "type": "array",
             "description": "AT-URI references to parent entries. DAG linkage for lineage, provenance, context.",
             "items": { "type": "string", "format": "at-uri" },
-            "maxLength": 3
           },
           "createdAt": {
             "type": "string",

--- a/lexicons/network/sporechain/entry.json
+++ b/lexicons/network/sporechain/entry.json
@@ -34,7 +34,7 @@
           },
           "sourceUri": {
             "type": "string",
-            "description": "Original locator for the content. An https:// URL, at:// URI, or doi: identifier.",
+            "description": "Original locator for the content being attested to. An at:// URI for on-protocol records, https:// URL or doi: for off-protocol content.",
             "maxLength": 2048
           },
           "sourceCollection": {
@@ -54,7 +54,7 @@
           },
           "parents": {
             "type": "array",
-            "description": "AT-URI references for DAG linkage. Lineage, provenance, context.",
+            "description": "References to other network.sporechain.entry records. Entry-to-entry DAG edges for lineage, provenance, and social structure.",
             "items": { "type": "string", "format": "at-uri" }
           },
           "createdAt": {

--- a/lexicons/network/sporechain/entry.json
+++ b/lexicons/network/sporechain/entry.json
@@ -4,11 +4,11 @@
   "defs": {
     "main": {
       "type": "record",
-      "description": "A biodiversity data entry. The minimal, signed, taxonomically-anchored link that forms the Sporechain network. Entries are the chain. Content lives above.",
+      "description": "A signed stewardship attestation by a DID about content at a point in time. The atomic unit of the Sporechain network.",
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["subject", "createdAt"],
+        "required": ["subject", "kind", "createdAt"],
         "properties": {
           "subject": {
             "type": "string",
@@ -16,21 +16,46 @@
             "minLength": 1,
             "maxLength": 300
           },
-          "tags": {
-            "type": "array",
-            "description": "Classification tags (entry type, kingdom, provenance, etc.)",
-            "items": { "type": "string", "maxLength": 64 },
-            "maxLength": 8
+          "kind": {
+            "type": "string",
+            "description": "What this entry is doing operationally. Extensible via knownValues.",
+            "knownValues": [
+              "mirroredRecord",
+              "mirroredDocument",
+              "archivedAtprotoRecord",
+              "pinningAttestation",
+              "witness"
+            ]
           },
           "cid": {
             "type": "string",
-            "description": "IPFS CID pointing to content payload (images, docs, data, custom pages).",
+            "description": "IPFS CID pointing to content payload. Required for all kinds except witness.",
             "maxLength": 512
+          },
+          "sourceUri": {
+            "type": "string",
+            "description": "Original locator for the content. An https:// URL, at:// URI, or doi: identifier.",
+            "maxLength": 2048
+          },
+          "sourceCollection": {
+            "type": "string",
+            "description": "Semantic label for the source system and record (e.g. mycoportal:occurrence:12345, gbif:occurrence:4567).",
+            "maxLength": 512
+          },
+          "mirroredAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the content was pinned or snapshotted. Distinct from createdAt."
+          },
+          "tags": {
+            "type": "array",
+            "description": "Classification tags: record type, kingdom, provenance, custom.",
+            "items": { "type": "string", "maxLength": 64 }
           },
           "parents": {
             "type": "array",
-            "description": "AT-URI references to parent entries. DAG linkage for lineage, provenance, context.",
-            "items": { "type": "string", "format": "at-uri" },
+            "description": "AT-URI references for DAG linkage. Lineage, provenance, context.",
+            "items": { "type": "string", "format": "at-uri" }
           },
           "createdAt": {
             "type": "string",


### PR DESCRIPTION
Brings the lexicon up to the v2 architecture. Adds kind (extensible via knownValues), sourceUri, sourceCollection, and mirroredAt. Removes arbitrary caps on parents and tags. Updates README.